### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/k8s/charts/colanode/index.yaml
+++ b/k8s/charts/colanode/index.yaml
@@ -60,7 +60,7 @@ entries:
         - name: minio-client
           image: docker.io/bitnami/minio-client:2025.4.16-debian-12-r1
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r43
+          image: docker.io/soldevelo/os-shell:12-debian-12-r3
       licenses: Apache-2.0
       tanzuCategory: service
     apiVersion: v2
@@ -98,9 +98,9 @@ entries:
       category: Database
       images: |
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r43
+          image: docker.io/soldevelo/os-shell:12-debian-12-r3
         - name: postgres-exporter
-          image: docker.io/bitnami/postgres-exporter:0.17.1-debian-12-r7
+          image: docker.io/soldevelo/postgres-exporter:0.17.1-debian-12-r0
         - name: postgresql
           image: docker.io/bitnami/postgresql:17.5.0-debian-12-r3
       licenses: Apache-2.0
@@ -141,9 +141,9 @@ entries:
       category: Database
       images: |
         - name: kubectl
-          image: docker.io/bitnami/kubectl:1.33.0-debian-12-r0
+          image: docker.io/soldevelo/kubectl:1.33.4-debian-12-r0
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r43
+          image: docker.io/soldevelo/os-shell:12-debian-12-r3
         - name: redis-exporter
           image: docker.io/bitnami/redis-exporter:1.70.0-debian-12-r2
         - name: valkey


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/os-shell:12-debian-12-r43` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/postgres-exporter:0.17.1-debian-12-r7` → [`soldevelo/postgres-exporter:0.17.1-debian-12-r0`](https://hub.docker.com/r/soldevelo/postgres-exporter)
- `bitnami/kubectl:1.33.0-debian-12-r0` → [`soldevelo/kubectl:1.33.4-debian-12-r0`](https://hub.docker.com/r/soldevelo/kubectl)